### PR TITLE
Add ERC to publication list

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,9 @@
             <a href="https://safe.global/blog/harbour-towards-fully-onchain-multisig-operations" target="_blank">Harbour: Towards Fully Onchain Multisig Operations</a>
           </li>
           <li>
+            <a href="https://ethereum-magicians.org/t/multi-chain-deployment-process-for-a-permissionless-contract-factory/24318" target="_blank">ERC-7955 Permissionless CREATE2 Factory</a>
+          </li>
+          <li>
             <a href="https://safe.global/blog/safe-research-manifesto" target="_blank">Safe Research Manifesto</a>
           </li>
         </ul>


### PR DESCRIPTION
- The ERC is a publication, so we should link it to show it off and to get more eyes on it.
- I know, the timeline is now not 100% correct. The ERC was posted before the manifesto. But I think it's better to have the manifesto at the bottom since it marks the "start" and explains the purpose of all this

<img width="966" height="648" alt="image" src="https://github.com/user-attachments/assets/a28c7419-97fa-4de3-a09b-0942ba819b90" />

