### PR TITLE
Move Manifesto Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,8 @@
             <a href="https://github.com/remedcu"><img src="https://avatars.githubusercontent.com/u/30735581?s=200" width="100" height="100" alt="remedcu" /></a>
         </div>
         <div class="contact">
+          <a href="https://safe.global/blog/safe-research-manifesto" target="_blank">Our Manifesto</a>
+          &hearts;
           <a href="https://github.com/safe-research" target="_blank">Find us on GitHub</a>
           &hearts;
           <a href="#" id="contact-link">Send us an Email</a>
@@ -76,9 +78,6 @@
           </li>
           <li>
             <a href="https://ethereum-magicians.org/t/multi-chain-deployment-process-for-a-permissionless-contract-factory/24318" target="_blank">ERC-7955 Permissionless CREATE2 Factory</a>
-          </li>
-          <li>
-            <a href="https://safe.global/blog/safe-research-manifesto" target="_blank">Safe Research Manifesto</a>
           </li>
         </ul>
         <p class="spacer">///////////////////////////////////////////////////////</p>


### PR DESCRIPTION
This PR proposes moving the manifesto link with the contact links. The
rationale is that our manifesto is more of a "permanent" page that
should not get buried at the bottom of the publications.

This is just a suggestion from my part - if you all don't think it works
the way I proposed, feel free to close the PR.

<img width="847" height="551" alt="image" src="https://github.com/user-attachments/assets/0abc1160-b345-4bc3-b8a3-a6d5ecdf4703" />
