### PR TITLE
Add link to ERC-7955 blog post

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -50,11 +50,6 @@
             <title>Harbour: Towards Fully Onchain Multisig Operations</title>
             <description>Harbour: Towards Fully Onchain Multisig Operations</description>
         </item>
-        <item>
-            <link>https://ethereum-magicians.org/t/multi-chain-deployment-process-for-a-permissionless-contract-factory/24318</link>
-            <title>ERC-7955 Permissionless CREATE2 Factory</title>
-            <description>ERC-7955 Permissionless CREATE2 Factory</description>
-        </item>
     </channel>
 
 </rss>

--- a/feed.xml
+++ b/feed.xml
@@ -6,6 +6,11 @@
         <link>https://safe.global/blog?category=Safe+Research&amp;utm_source=safe_rss</link>
         <description>Latest updates on publications from the Safe Research team</description>
         <item>
+            <link>https://safe.global/blog/safe-research-meet-erc-7955-no-private-key-required?utm_source=safe_rss</link>
+            <title>Meet ERC-7955: No Private Key Required</title>
+            <description>Meet ERC-7955: No Private Key Required</description>
+        </item>
+        <item>
             <link>https://safe.global/blog/safe-research-fiducia-onchain-trust-rules-and-cosigning?utm_source=safe_rss</link>
             <title>Fiducia: Onchain Trust Rules and Cosigning</title>
             <description>Fiducia: Onchain Trust Rules and Cosigning</description>

--- a/index.html
+++ b/index.html
@@ -106,9 +106,6 @@
           <li>
             <a href="https://safe.global/blog/harbour-towards-fully-onchain-multisig-operations?utm_source=safe_dev" target="_blank">Harbour: Towards Fully Onchain Multisig Operations</a>
           </li>
-          <li>
-            <a href="https://eips.ethereum.org/EIPS/eip-7955" target="_blank">ERC-7955: Permissionless CREATE2 Factory</a>
-          </li>
         </ul>
         <p class="spacer">///////////////////////////////////////////////////////</p>
         <div class="footer-section">

--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
+
     <!-- Primary Meta Tags -->
     <title>Safe Research - Advancing Self-Custody Wallet Technology</title>
     <meta name="title" content="Safe Research - Advancing Self-Custody Wallet Technology">
     <meta name="description" content="Safe Research is dedicated to advancing the future of self-custody wallets through cutting-edge research in threshold signatures, multisig operations, and secure blockchain technology.">
     <meta name="keywords" content="Safe Research, self-custody wallets, safe, threshold signatures, safe multisig, FROST, Harbour, Guardrail, ERC-7955, Smart Contracts">
     <meta name="author" content="Safe Research Team">
-    
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.safe.dev/">
@@ -18,14 +18,14 @@
     <meta property="og:description" content="Safe Research is dedicated to advancing the future of self-custody wallets through cutting-edge research in threshold signatures, multisig operations, and secure blockchain technology.">
     <meta property="og:image" content="https://www.safe.dev/assets/images/banner.png">
     <meta property="og:site_name" content="Safe Research">
-    
+
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://www.safe.dev/">
     <meta property="twitter:title" content="Safe Research - Advancing Self-Custody Wallet Technology">
     <meta property="twitter:description" content="Safe Research is dedicated to advancing the future of self-custody wallets through cutting-edge research in threshold signatures, multisig operations, and secure blockchain technology.">
     <meta property="twitter:image" content="https://www.safe.dev/assets/images/banner.png">
-    
+
     <!-- Schema.org markup -->
     <script type="application/ld+json">
     {
@@ -41,13 +41,13 @@
       ]
     }
     </script>
-    
+
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="./assets/images/icons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="./assets/images/icons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="./assets/images/icons/favicon-16x16.png">
     <link rel="manifest" href="./site.webmanifest">
-    
+
     <!-- Stylesheets -->
     <link rel="stylesheet" href="./assets/css/style.css">
 
@@ -80,6 +80,9 @@
         <p class="spacer">///////////////////////////////////////////////////////</p>
         <ul>
           <li>
+            <a href="https://safe.global/blog/safe-research-meet-erc-7955-no-private-key-required?utm_source=safe_dev" target="_blank">Meet ERC-7955: No Private Key Required</a>
+          </li>
+          <li>
             <a href="https://safe.global/blog/safe-research-fiducia-onchain-trust-rules-and-cosigning?utm_source=safe_dev" target="_blank">Fiducia: Onchain Trust Rules and Cosigning</a>
           </li>
           <li>
@@ -104,7 +107,7 @@
             <a href="https://safe.global/blog/harbour-towards-fully-onchain-multisig-operations?utm_source=safe_dev" target="_blank">Harbour: Towards Fully Onchain Multisig Operations</a>
           </li>
           <li>
-            <a href="https://ethereum-magicians.org/t/multi-chain-deployment-process-for-a-permissionless-contract-factory/24318" target="_blank">ERC-7955 Permissionless CREATE2 Factory</a>
+            <a href="https://eips.ethereum.org/EIPS/eip-7955" target="_blank">ERC-7955: Permissionless CREATE2 Factory</a>
           </li>
         </ul>
         <p class="spacer">///////////////////////////////////////////////////////</p>


### PR DESCRIPTION
Additionally, I modified the original ERC-7955 link to point to the ERC hosted on ethereum.org.

<img width="1482" height="1262" alt="image" src="https://github.com/user-attachments/assets/8f8b3ad2-0710-45e2-a9e6-514b7c0c5bc5" />
